### PR TITLE
Adding separators for scenes when exporting a manuscript

### DIFF
--- a/components/ExportModal.ts
+++ b/components/ExportModal.ts
@@ -19,11 +19,16 @@ export class ExportModal extends Modal {
     private numberScenesOnExport = false;
     private includeCorkboardNotes = false;
     private includeInactiveScenes = false;
+    private sceneSeparatorType: 'blank' | 'asterisks' | 'custom' = 'blank';
+    private sceneSeparatorCustom = '';
 
     constructor(plugin: SceneCardsPlugin) {
         super(plugin.app);
         this.plugin = plugin;
         this.exportService = new ExportService(plugin.app, plugin.sceneManager, plugin.characterManager, plugin.locationManager);
+        
+        this.sceneSeparatorType = plugin.settings.exportSceneSeparatorType || 'blank';
+        this.sceneSeparatorCustom = plugin.settings.exportSceneSeparatorCustom || '';
         // Pass DOCX settings to the export service
         if (plugin.settings.docxSettings) {
             this.exportService.setDocxSettings(plugin.settings.docxSettings);
@@ -153,6 +158,37 @@ export class ExportModal extends Modal {
                     t.onChange(v => { this.includeCorkboardNotes = v; });
                 });
 
+            new Setting(manuscriptOptions)
+                .setName('Scene separator')
+                .setDesc('Separator used between scenes in manuscript exports.')
+                .addDropdown(dd => dd
+                    .addOptions({
+                        'blank': 'Blank Line',
+                        'asterisks': '* * *',
+                        'custom': 'Custom Separator',
+                    })
+                    .setValue(this.sceneSeparatorType)
+                    .onChange(async (v) => {
+                        this.sceneSeparatorType = v as 'blank' | 'asterisks' | 'custom';
+                        this.plugin.settings.exportSceneSeparatorType = this.sceneSeparatorType;
+                        await this.plugin.saveSettings();
+                        renderManuscriptOptions();
+                    }));
+
+            if (this.sceneSeparatorType === 'custom') {
+                new Setting(manuscriptOptions)
+                    .setName('Custom separator')
+                    .setDesc('Enter any UTF-8 character or text to use as a scene separator.')
+                    .addText(text => text
+                        .setPlaceholder('e.g. ~ ~ ~')
+                        .setValue(this.sceneSeparatorCustom)
+                        .onChange(async (v) => {
+                            this.sceneSeparatorCustom = v;
+                            this.plugin.settings.exportSceneSeparatorCustom = v;
+                            await this.plugin.saveSettings();
+                        }));
+            }
+
         };
         renderManuscriptOptions();
 
@@ -168,6 +204,10 @@ export class ExportModal extends Modal {
                     includeCorkboardNotes: this.includeCorkboardNotes,
                     includeInactiveScenes: this.includeInactiveScenes,
                 });
+                this.exportService.setSeparatorSettings(
+                    this.sceneSeparatorType,
+                    this.sceneSeparatorCustom
+                );
                 await this.exportService.export(this.format, this.exportScope);
                 this.close();
             } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-storyline",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-storyline",
-      "version": "1.10.27",
+      "version": "1.10.28",
       "license": "MIT",
       "dependencies": {
         "@pdf-lib/fontkit": "^1.1.1",

--- a/services/DocxConverter.ts
+++ b/services/DocxConverter.ts
@@ -70,7 +70,7 @@ export interface SLObsidianFontSettings {
 }
 
 interface SLDocumentElement {
-    type: 'paragraph' | 'heading' | 'list' | 'codeblock' | 'table' | 'break' | 'blockquote' | 'tasklist' | 'horizontal-rule' | 'image';
+    type: 'paragraph' | 'heading' | 'list' | 'codeblock' | 'table' | 'break' | 'blockquote' | 'tasklist' | 'horizontal-rule' | 'image' | 'scene-separator';
     content?: string;
     level?: number;
     style?: SLTextStyle;
@@ -681,12 +681,18 @@ ${imageRels}</Relationships>`;
                 case 'horizontal-rule': return this.horizontalRuleToXml();
                 case 'image': return this.imageToXml(element);
                 case 'break': return '<w:p><w:pPr></w:pPr></w:p>';
+                case 'scene-separator': return this.sceneSeparatorToXml(element);
                 default: return '';
             }
         } catch (error) {
             console.error('StoryLine DOCX: Error converting element to XML:', element.type, error);
             return `<w:p><w:pPr></w:pPr><w:r><w:t>[Error processing ${element.type}]</w:t></w:r></w:p>`;
         }
+    }
+
+    private sceneSeparatorToXml(element: SLDocumentElement): string {
+        const text = this.escapeXml(element.content || '* * *');
+        return `<w:p>\n  <w:pPr>\n    <w:jc w:val="center"/>\n    <w:spacing w:before="240" w:after="240"/>\n  </w:pPr>\n  <w:r>\n    <w:t>${text}</w:t>\n  </w:r>\n</w:p>`;
     }
 
     private headingToXml(element: SLDocumentElement): string {
@@ -1261,6 +1267,17 @@ ${imageRels}</Relationships>`;
             }
 
             const trimmedLine = line.trim();
+
+            // Scene separators
+            const separatorMatch = trimmedLine.match(/^<div\s+class="scene-separator">(.*?)<\/div>/i);
+            if (separatorMatch) {
+                elements.push({
+                    type: 'scene-separator',
+                    content: separatorMatch[1].trim()
+                });
+                i++;
+                continue;
+            }
 
             // Horizontal rules
             const cleanLine = trimmedLine.replace(/\s/g, '');

--- a/services/DocxConverter.ts
+++ b/services/DocxConverter.ts
@@ -99,7 +99,7 @@ export class SLMarkdownToDocxConverter {
     private footnotes: { [key: string]: string } = {};
     private usedFootnotes: string[] = [];
     private imageCounter: number = 0;
-    private imageRelationships: Array<{id: string, data: ArrayBuffer, extension: string}> = [];
+    private imageRelationships: Array<{ id: string, data: ArrayBuffer, extension: string }> = [];
     private md: MarkdownIt;
 
     constructor(settings: SLDocxSettings) {
@@ -692,7 +692,7 @@ ${imageRels}</Relationships>`;
 
     private sceneSeparatorToXml(element: SLDocumentElement): string {
         const text = this.escapeXml(element.content || '* * *');
-        return `<w:p>\n  <w:pPr>\n    <w:jc w:val="center"/>\n    <w:spacing w:before="240" w:after="240"/>\n  </w:pPr>\n  <w:r>\n    <w:t>${text}</w:t>\n  </w:r>\n</w:p>`;
+        return `<w:p>\n  <w:pPr>\n    <w:jc w:val="center"/>\n    <w:spacing w:before="240" w:after="240"/>\n  </w:pPr>\n  <w:r>\n    <w:t xml:space="preserve">${text}</w:t>\n  </w:r>\n</w:p>`;
     }
 
     private headingToXml(element: SLDocumentElement): string {
@@ -1273,7 +1273,7 @@ ${imageRels}</Relationships>`;
             if (separatorMatch) {
                 elements.push({
                     type: 'scene-separator',
-                    content: separatorMatch[1].trim()
+                    content: this.decodeHtmlEntities(separatorMatch[1].trim())
                 });
                 i++;
                 continue;
@@ -1580,14 +1580,8 @@ ${imageRels}</Relationships>`;
     }
 
     private decodeHtmlEntities(text: string): string {
-        return text
-            .replace(/&#x27;/g, "'")
-            .replace(/&#x22;/g, '"')
-            .replace(/&quot;/g, '"')
-            .replace(/&apos;/g, "'")
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>')
-            .replace(/&amp;/g, '&');
+        const doc = new DOMParser().parseFromString(text, 'text/html');
+        return doc.documentElement.textContent || '';
     }
 
     private extractFootnotes(markdown: string): { content: string; definitions: Map<string, string> } {

--- a/services/ExportService.ts
+++ b/services/ExportService.ts
@@ -228,14 +228,10 @@ export class ExportService {
             const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
             if (nextScene && !startsNewAct && !startsNewChapter) {
                 if (this.separatorType === 'asterisks') {
-                    lines.push('\\* \\* \\*');
+                    lines.push('<div class="scene-separator">* * *</div>');
                     lines.push('');
                 } else if (this.separatorType === 'custom' && this.separatorCustom) {
-                    let custom = this.separatorCustom;
-                    if (/^[ \-*_]+$/.test(custom) && (custom.match(/[*-_]/g) || []).length >= 3) {
-                        custom = custom.replace(/([*-_])/g, '\\$1');
-                    }
-                    lines.push(custom);
+                    lines.push(`<div class="scene-separator">${this.separatorCustom}</div>`);
                     lines.push('');
                 }
             }

--- a/services/ExportService.ts
+++ b/services/ExportService.ts
@@ -223,17 +223,10 @@ export class ExportService {
             }
 
             // Scene separator
-            const nextScene = scenes[sceneNumber];
-            const startsNewAct = nextScene && nextScene.act !== undefined && nextScene.act !== currentAct;
-            const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
-            if (nextScene && !startsNewAct && !startsNewChapter) {
-                if (this.separatorType === 'asterisks') {
-                    lines.push('<div class="scene-separator">* * *</div>');
-                    lines.push('');
-                } else if (this.separatorType === 'custom' && this.separatorCustom) {
-                    lines.push(`<div class="scene-separator">${this.separatorCustom}</div>`);
-                    lines.push('');
-                }
+            const separatorHtml = this.getSceneSeparator(scenes[sceneNumber], currentAct, currentChapter);
+            if (separatorHtml) {
+                lines.push(separatorHtml);
+                lines.push('');
             }
         }
     }
@@ -614,15 +607,9 @@ ${body}
             parts.push('</div>');
 
             // Scene separator
-            const nextScene = scenes[sceneNumber];
-            const startsNewAct = nextScene && nextScene.act !== undefined && nextScene.act !== currentAct;
-            const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
-            if (nextScene && !startsNewAct && !startsNewChapter) {
-                if (this.separatorType === 'asterisks') {
-                    parts.push('<div class="scene-separator">* * *</div>');
-                } else if (this.separatorType === 'custom' && this.separatorCustom) {
-                    parts.push(`<div class="scene-separator">${this.escHtml(this.separatorCustom)}</div>`);
-                }
+            const separatorHtml = this.getSceneSeparator(scenes[sceneNumber], currentAct, currentChapter);
+            if (separatorHtml) {
+                parts.push(separatorHtml);
             }
         }
 
@@ -835,6 +822,28 @@ ${body}
         }
 
         return filePath;
+    }
+
+    /**
+     * Determines whether to insert a scene separator before nextScene,
+     * and returns the formatted HTML element for the separator (with properly escaped content)
+     * if applicable. Returns an empty string if no separator is needed.
+     */
+    private getSceneSeparator(
+        nextScene: Scene | undefined,
+        currentAct: string | number | undefined,
+        currentChapter: string | number | undefined
+    ): string {
+        const startsNewAct = nextScene && nextScene.act !== undefined && nextScene.act !== currentAct;
+        const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
+        if (nextScene && !startsNewAct && !startsNewChapter) {
+            if (this.separatorType === 'asterisks') {
+                return '<div class="scene-separator">* * *</div>';
+            } else if (this.separatorType === 'custom' && this.separatorCustom) {
+                return `<div class="scene-separator">${this.escHtml(this.separatorCustom)}</div>`;
+            }
+        }
+        return '';
     }
 
     private escHtml(s: string): string {

--- a/services/ExportService.ts
+++ b/services/ExportService.ts
@@ -44,6 +44,8 @@ export class ExportService {
         includeCorkboardNotes: false,
         includeInactiveScenes: false,
     };
+    private separatorType: 'blank' | 'asterisks' | 'custom' = 'blank';
+    private separatorCustom = '';
 
     constructor(app: App, sceneManager: SceneManager, characterManager: CharacterManager, locationManager: LocationManager) {
         this.app = app;
@@ -65,6 +67,12 @@ export class ExportService {
     /** Set per-export options (scene titles, numbering, corkboard notes). */
     setExportOptions(options: ExportOptions): void {
         this.exportOptions = { ...this.exportOptions, ...options };
+    }
+
+    /** Set scene separator options. */
+    setSeparatorSettings(type: 'blank' | 'asterisks' | 'custom', custom: string): void {
+        this.separatorType = type;
+        this.separatorCustom = custom;
     }
 
     /**
@@ -214,7 +222,23 @@ export class ExportService {
                 lines.push('');
             }
 
-            // (no divider between scenes – the heading structure is sufficient)
+            // Scene separator
+            const nextScene = scenes[sceneNumber];
+            const startsNewAct = nextScene && nextScene.act !== undefined && nextScene.act !== currentAct;
+            const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
+            if (nextScene && !startsNewAct && !startsNewChapter) {
+                if (this.separatorType === 'asterisks') {
+                    lines.push('\\* \\* \\*');
+                    lines.push('');
+                } else if (this.separatorType === 'custom' && this.separatorCustom) {
+                    let custom = this.separatorCustom;
+                    if (/^[ \-*_]+$/.test(custom) && (custom.match(/[*-_]/g) || []).length >= 3) {
+                        custom = custom.replace(/([*-_])/g, '\\$1');
+                    }
+                    lines.push(custom);
+                    lines.push('');
+                }
+            }
         }
     }
 
@@ -526,6 +550,7 @@ export class ExportService {
     h5 { font-size: 11pt; margin-top: 0.9em; font-weight: 600; }
     h6 { font-size: 10pt; margin-top: 0.8em; font-weight: 600; color: #666; }
     hr { border: none; border-top: 1px solid #ccc; margin: 1.5em 0; }
+    .scene-separator { text-align: center; margin: 1.5em 0; }
     table { width: 100%; border-collapse: collapse; font-size: 10pt; margin: 1em 0; }
     th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
     th { background: #f5f5f5; font-weight: 600; }
@@ -591,6 +616,18 @@ ${body}
             }
 
             parts.push('</div>');
+
+            // Scene separator
+            const nextScene = scenes[sceneNumber];
+            const startsNewAct = nextScene && nextScene.act !== undefined && nextScene.act !== currentAct;
+            const startsNewChapter = nextScene && nextScene.chapter !== undefined && nextScene.chapter !== currentChapter;
+            if (nextScene && !startsNewAct && !startsNewChapter) {
+                if (this.separatorType === 'asterisks') {
+                    parts.push('<div class="scene-separator">* * *</div>');
+                } else if (this.separatorType === 'custom' && this.separatorCustom) {
+                    parts.push(`<div class="scene-separator">${this.escHtml(this.separatorCustom)}</div>`);
+                }
+            }
         }
 
         return parts.join('\n');
@@ -1288,6 +1325,7 @@ ${body}
     h6 { font-size: ${h6Size}pt; margin-top: 0.8em; font-weight: 600; color: #666; }
     p  { margin: 0 0 0.5em 0; }
     hr { border: none; border-top: 1px solid #ccc; margin: 1.5em 0; }
+    .scene-separator { text-align: center; margin: 1.5em 0; }
     table { width: 100%; border-collapse: collapse; font-size: ${Math.round(fontSize * 0.9)}pt; margin: 1em 0; }
     th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
     th { background: #f5f5f5; font-weight: 600; }

--- a/settings.ts
+++ b/settings.ts
@@ -793,6 +793,9 @@ export interface SceneCardsSettings {
      * on conflict.
      */
     defaultSceneFrontmatter?: string;
+
+    exportSceneSeparatorType?: 'blank' | 'asterisks' | 'custom';
+    exportSceneSeparatorCustom?: string;
 }
 
 /**
@@ -905,6 +908,8 @@ export const DEFAULT_SETTINGS: SceneCardsSettings = {
     excludeChecklistFromWordcount: false,
     defaultProjectLanguage: 'en',
     defaultSceneFrontmatter: '',
+    exportSceneSeparatorType: 'blank',
+    exportSceneSeparatorCustom: '',
 };
 
 /**
@@ -2166,6 +2171,35 @@ export class SceneCardsSettingTab extends PluginSettingTab {
         //  Export & Import
         // ═══════════════════════════════════════════
         new Setting(containerEl).setName('Export & Import').setHeading();
+
+        new Setting(containerEl)
+            .setName('Scene separator')
+            .setDesc('Separator used between scenes in manuscript exports (Markdown, Word, PDF, and HTML).')
+            .addDropdown(dropdown => dropdown
+                .addOptions({
+                    'blank': 'Blank Line',
+                    'asterisks': '* * *',
+                    'custom': 'Custom Separator',
+                })
+                .setValue(this.plugin.settings.exportSceneSeparatorType ?? 'blank')
+                .onChange(async (value) => {
+                    this.plugin.settings.exportSceneSeparatorType = value as 'blank' | 'asterisks' | 'custom';
+                    await this.plugin.saveSettings();
+                    this.refreshSettingsView();
+                }));
+
+        if (this.plugin.settings.exportSceneSeparatorType === 'custom') {
+            new Setting(containerEl)
+                .setName('Custom separator')
+                .setDesc('Enter any UTF-8 character or text to use as a scene separator.')
+                .addText(text => text
+                    .setPlaceholder('e.g. ~ ~ ~')
+                    .setValue(this.plugin.settings.exportSceneSeparatorCustom ?? '')
+                    .onChange(async (value) => {
+                        this.plugin.settings.exportSceneSeparatorCustom = value;
+                        await this.plugin.saveSettings();
+                    }));
+        }
 
         // --- DOCX Export Settings (collapsible) ---
         this.renderDocxSettings(containerEl);

--- a/settings.ts
+++ b/settings.ts
@@ -794,7 +794,16 @@ export interface SceneCardsSettings {
      */
     defaultSceneFrontmatter?: string;
 
+    /**
+     * Type of separator to insert between scenes in manuscript exports.
+     * Can be a blank line, three asterisks (* * *), or a custom text string.
+     */
     exportSceneSeparatorType?: 'blank' | 'asterisks' | 'custom';
+
+    /**
+     * Custom text/separator string to insert between scenes in manuscript exports
+     * when `exportSceneSeparatorType` is set to 'custom'.
+     */
     exportSceneSeparatorCustom?: string;
 }
 


### PR DESCRIPTION
Great plugin. It gives a lot of features that even some of the dedicated pieces of software don't, such as Scrivener.

I have added a new feature to help with the presentation of a document when exporting.

When exporting a manuscript all of the scenes can run together, which means that you have to add separators for each scene into the actual text of the scene if you want them.

Now, you can configure what separators you want for a scene, choosing from a blank line (default), or asterisks (* * *) or a custom separator. This allows for more flexibility of how your manuscript looks.