### PR TITLE
Fix manuscript scenes rendering blank when editors mount concurrently

### DIFF
--- a/views/ManuscriptView.ts
+++ b/views/ManuscriptView.ts
@@ -550,12 +550,12 @@ export class ManuscriptView extends ItemView {
         this.mountingPaths.add(filePath);
         this._lazyMounting = true;
 
-        // Capture a token for this mount so we can detect if a teardown
-        // (detachAllEmbedded) ran while we were awaiting openFile(). Without
-        // this, a refresh() triggered by the modify event from openFile()
-        // would leave us writing into a detached container.
-        const mountToken = Symbol('mount');
-        this._activeMountToken = mountToken;
+        // Snapshot the current teardown token so we can detect if
+        // detachAllEmbedded() ran while we were awaiting openFile(). Don't
+        // mint a per-mount token: concurrent mounts in the same render cycle
+        // (eager loop + IntersectionObserver) would invalidate each other
+        // and leave freshly opened leaves detached, rendering scenes blank.
+        const mountToken = this._activeMountToken;
 
         const file = this.app.vault.getAbstractFileByPath(filePath);
         if (!(file instanceof TFile)) {


### PR DESCRIPTION
**AI ASSISTED**

mountEditor() minted a fresh per-call Symbol and wrote it to the shared _activeMountToken on every invocation. When more than one editor mounts in the same render cycle - the eager loop in renderManuscript() racing the IntersectionObserver's un-awaited mountEditor() calls (rootMargin 400px pulls in the first few scenes at once) - each new mount's token overwrote the previous one. The earlier mounts, still awaiting leaf.openFile(), then saw _activeMountToken !== mountToken on resume, called leaf.detach() and bailed, leaving those scene blocks blank. Which scenes survived depended on timing, so the manuscript intermittently showed only a subset of scene bodies (headers still rendered).

The token only needs to detect a detachAllEmbedded() teardown during the await. detachAllEmbedded() is already the sole writer of a fresh Symbol('detach'). Snapshot that value at mount start instead of minting a new one, so concurrent sibling mounts share the same token and no longer invalidate each other, while a real teardown still bumps the token and cancels every in-flight mount as before.

Before:
<img width="871" height="985" alt="image" src="https://github.com/user-attachments/assets/4a5256a7-2f54-4c25-8c4d-312608fb0d89" />

After:
<img width="811" height="744" alt="image" src="https://github.com/user-attachments/assets/0a455e1b-1f3f-4796-ae42-eb3b898ba5fc" />
